### PR TITLE
Fix typo in setup_simple.sh with the msgrouter.service template

### DIFF
--- a/setup_simple.sh
+++ b/setup_simple.sh
@@ -51,7 +51,7 @@ StartLimitIntervalSec=0
 Type=simple
 Restart=always
 RestartSec=1
-User${php_user}
+User=${php_user}
 ExecStart=/usr/bin/php ${document_root}/routing/msgRouter.php
 
 [Install]

--- a/siikr/siikr_db_setup.sql
+++ b/siikr/siikr_db_setup.sql
@@ -1256,21 +1256,6 @@ GRANT ALL ON TABLE public.tags TO siikrweb;
 
 GRANT ALL ON SEQUENCE public.tags_tag_id_seq TO siikrweb;
 
-
---
--- Name: DEFAULT PRIVILEGES FOR SEQUENCES; Type: DEFAULT ACL; Schema: public; Owner: -
---
-
-ALTER DEFAULT PRIVILEGES FOR ROLE eron IN SCHEMA public GRANT ALL ON SEQUENCES  TO siikrweb;
-
-
---
--- Name: DEFAULT PRIVILEGES FOR TABLES; Type: DEFAULT ACL; Schema: public; Owner: -
---
-
-ALTER DEFAULT PRIVILEGES FOR ROLE eron IN SCHEMA public GRANT ALL ON TABLES  TO siikrweb;
-
-
 --
 -- PostgreSQL database dump complete
 --


### PR DESCRIPTION
Add equals sign for the `User` line

I just noticed this while I was working on the dockerization and getting the msgrouter service installed on the container.