### PR TITLE
Add visual query builder to search interface

### DIFF
--- a/setup_simple.sh
+++ b/setup_simple.sh
@@ -157,6 +157,7 @@ ExecStart=/usr/bin/php ${document_root}/siikr/routing/msgRouter.php
 WantedBy=multi-user.target
 EOF
     sudo mkdir -p "$document_root/siikr/routing/"
+    sudo cp "$node_specific_data/routing/msgrouter.service" "$document_root/siikr/routing/msgrouter.service"
     sudo cp "$document_root/siikr/routing/msgrouter.service" /etc/systemd/system/msgrouter.service
     sudo systemctl daemon-reload
     sudo systemctl enable msgrouter.service

--- a/siikr/css/sikr-css.css
+++ b/siikr/css/sikr-css.css
@@ -473,6 +473,7 @@ details summary {
 
 #search-fields-container {
 	display: flex;
+	position: relative;
 	width: 100%;
 	max-width: 50em;
 	justify-content: stretch;
@@ -1991,4 +1992,164 @@ b {}
 
 .texted-light * {
     display: contents;
+}
+
+/* ---- Query Builder ---- */
+.qb-anchor {
+    position: absolute;
+    right: 0;
+    top: 0;
+    bottom: 0;
+    width: 0;
+    overflow: visible;
+}
+
+button#qb-toggle {
+    background-color: #0000;
+    border-style: hidden;
+    color: white;
+    font-size: 2em;
+    cursor: pointer;
+    margin-right: 0.1em;
+    margin-left: 0em;
+    margin-top: auto;
+    margin-bottom: auto;
+    padding: 0 0.15em;
+    line-height: 1;
+}
+
+button#qb-toggle.qb-toggle-active {
+    color: #7cf;
+    text-shadow: 0 0 8px #7cf8;
+}
+
+.qb-panel {
+    position: absolute;
+    top: 100%;
+    right: 0;
+    z-index: 10;
+    min-width: 28em;
+    max-width: calc(100vw - 2em);
+    background: rgba(0, 0, 0, 0.3);
+    border-radius: 8px;
+    border: 1px solid #ffffff22;
+    padding: 0.5em 0.6em;
+    box-sizing: border-box;
+}
+
+.qb-group {
+    border-left: 3px solid #ffffff55;
+    padding-left: 1em;
+    margin-bottom: 0.5em;
+}
+.qb-group:first-child { margin-top: 0; }
+
+.qb-group-items {
+    margin-top: 0.25em;
+}
+
+.qb-group-header {
+    display: flex;
+    align-items: center;
+    gap: 0.4em;
+    margin-bottom: 0.3em;
+    flex-wrap: wrap;
+}
+
+.qb-combinator-btn {
+    background: #ffffff22;
+    border: 1px solid #ffffff44;
+    color: white;
+    border-radius: 4px;
+    cursor: pointer;
+    padding: 0.1em 0.5em;
+    font-size: 0.85em;
+    font-weight: bold;
+    min-width: 3em;
+}
+.qb-combinator-btn:hover { background: #ffffff33; }
+
+button.qb-add-term-btn,
+button.qb-add-group-btn {
+    background: transparent;
+    border: 1px solid #ffffff44;
+    color: white;
+    border-radius: 4px;
+    cursor: pointer;
+    padding: 0.2em 0.6em;
+    font-size: 0.85em;
+}
+button.qb-add-term-btn:hover,
+button.qb-add-group-btn:hover {
+    background: #ffffff11;
+}
+
+.qb-term {
+    display: flex;
+    gap: 0.4em;
+    margin-bottom: 0.4em;
+    align-items: center;
+    flex-wrap: wrap;
+}
+
+.qb-negate-label {
+    font-size: 0.85em;
+    color: lightgray;
+    display: flex;
+    align-items: center;
+    gap: 0.2em;
+    flex-shrink: 0;
+}
+
+select.qb-term-type {
+    background: transparent;
+    color: white;
+    border: 1px solid #ffffff44;
+    border-radius: 4px;
+    padding: 0.2em 0.3em;
+    flex-shrink: 0;
+}
+
+select.qb-term-type option {
+    background: #1c3248;
+    color: white;
+}
+
+input.qb-text {
+    flex-grow: 1;
+    background: transparent;
+    color: white;
+    border: 1px solid #ffffff44;
+    border-radius: 4px;
+    padding: 0.2em 0.4em;
+    font-size: inherit;
+    min-width: 5em;
+}
+
+input.qb-text::placeholder {
+    color: #aaa;
+}
+
+button.qb-remove-btn {
+    background: transparent;
+    border: none;
+    color: #f88;
+    cursor: pointer;
+    font-size: 1.1em;
+    padding: 0 0.3em;
+    flex-shrink: 0;
+}
+
+button.qb-remove-btn:hover {
+    color: #f44;
+}
+
+@media (max-width: 600px) {
+    .qb-term {
+        flex-wrap: wrap;
+    }
+    input.qb-text {
+        width: 100%;
+        flex-grow: 0;
+    }
 }

--- a/siikr/query_builder.php
+++ b/siikr/query_builder.php
@@ -1,0 +1,319 @@
+<span class="qb-anchor"><div id="qb-panel" class="qb-panel" style="display:none"></div></span>
+<script>
+function qbTokenize(str) {
+    var tokens = [];
+    var i = 0;
+    while (i < str.length) {
+        var c = str[i];
+        // Skip whitespace
+        if (c === ' ' || c === '\t' || c === '\n' || c === '\r') { i++; continue; }
+        // Quoted phrase
+        if (c === '"') {
+            var j = i + 1;
+            while (j < str.length && str[j] !== '"') j++;
+            tokens.push(str.slice(i, j + 1));
+            i = j + 1;
+            continue;
+        }
+        // Parens
+        if (c === '(' || c === ')') { tokens.push(c); i++; continue; }
+        // Unary minus: only when immediately followed by non-whitespace
+        if (c === '-' && i + 1 < str.length &&
+            str[i+1] !== ' ' && str[i+1] !== '\t' && str[i+1] !== '\n' && str[i+1] !== '\r') {
+            tokens.push('-');
+            i++;
+            continue;
+        }
+        // Word: run of chars that aren't whitespace, quote, paren
+        var k = i;
+        while (k < str.length &&
+               str[k] !== ' ' && str[k] !== '\t' && str[k] !== '\n' && str[k] !== '\r' &&
+               str[k] !== '"' && str[k] !== '(' && str[k] !== ')') {
+            k++;
+        }
+        if (k > i) { tokens.push(str.slice(i, k)); i = k; continue; }
+        i++; // skip unknown
+    }
+    return tokens;
+}
+
+function qbParseToTree(str) {
+    var tokens = qbTokenize(str);
+    var pos = 0;
+    function peek() { return pos < tokens.length ? tokens[pos] : null; }
+    function consume() { return tokens[pos++]; }
+
+    function parseOrExpr() {
+        var items = [];
+        var first = parseAndExpr();
+        if (first) items.push(first);
+        while (peek() && peek().toUpperCase() === 'OR') {
+            consume();
+            var next = parseAndExpr();
+            if (next) items.push(next);
+        }
+        if (items.length === 0) return null;
+        if (items.length === 1) return items[0];
+        return {type: 'group', combinator: 'OR', negate: false, items: items};
+    }
+
+    function parseAndExpr() {
+        var items = [];
+        while (peek() && peek().toUpperCase() !== 'OR' && peek() !== ')') {
+            var f = parseFactor();
+            if (f) items.push(f);
+        }
+        if (items.length === 0) return null;
+        if (items.length === 1) return items[0];
+        return {type: 'group', combinator: 'AND', negate: false, items: items};
+    }
+
+    function parseFactor() {
+        var negate = false;
+        if (peek() === '-') { consume(); negate = true; }
+        var atom = parseAtom();
+        if (!atom) return null;
+        atom.negate = negate;
+        return atom;
+    }
+
+    function parseAtom() {
+        var t = peek();
+        if (!t) return null;
+        if (t === '(') {
+            consume();
+            var expr = parseOrExpr();
+            if (peek() === ')') consume();
+            return expr;
+        }
+        if (t.charAt(0) === '"') {
+            consume();
+            var inner = t.length >= 2 && t.charAt(t.length - 1) === '"'
+                ? t.slice(1, t.length - 1) : t.slice(1);
+            return {type: 'term', termType: 'phrase', text: inner, negate: false};
+        }
+        if (t.toUpperCase() !== 'OR' && t !== ')') {
+            consume();
+            return {type: 'term', termType: 'word', text: t, negate: false};
+        }
+        return null;
+    }
+
+    var tree = parseOrExpr();
+    if (!tree) tree = {type: 'group', combinator: 'AND', negate: false, items: []};
+    return tree;
+}
+
+function qbRenderNode(nodeData, parentEl, isRoot) {
+    if (!nodeData) return;
+    if (nodeData.type === 'group') {
+        var group = document.createElement('div');
+        group.className = 'qb-group';
+        group.setAttribute('data-combinator', nodeData.combinator || 'AND');
+
+        var header = document.createElement('div');
+        header.className = 'qb-group-header';
+
+        var combBtn = document.createElement('button');
+        combBtn.className = 'qb-combinator-btn';
+        combBtn.type = 'button';
+        combBtn.textContent = nodeData.combinator || 'AND';
+        combBtn.setAttribute('onclick', 'qbToggleCombinator(this)');
+        header.appendChild(combBtn);
+
+        var negLabel = document.createElement('label');
+        negLabel.className = 'qb-negate-label';
+        var negChk = document.createElement('input');
+        negChk.type = 'checkbox';
+        negChk.className = 'qb-negate';
+        negChk.setAttribute('onchange', 'qbUpdate()');
+        if (nodeData.negate) negChk.checked = true;
+        negLabel.appendChild(negChk);
+        negLabel.appendChild(document.createTextNode(' NOT'));
+        header.appendChild(negLabel);
+
+        var addTermBtn = document.createElement('button');
+        addTermBtn.className = 'qb-add-term-btn';
+        addTermBtn.type = 'button';
+        addTermBtn.textContent = '+ term';
+        addTermBtn.setAttribute('onclick', 'qbAddTermToGroup(this)');
+        header.appendChild(addTermBtn);
+
+        var addGroupBtn = document.createElement('button');
+        addGroupBtn.className = 'qb-add-group-btn';
+        addGroupBtn.type = 'button';
+        addGroupBtn.textContent = '+ group';
+        addGroupBtn.setAttribute('onclick', 'qbAddGroupToGroup(this)');
+        header.appendChild(addGroupBtn);
+
+        if (!isRoot) {
+            var removeBtn = document.createElement('button');
+            removeBtn.className = 'qb-remove-btn';
+            removeBtn.type = 'button';
+            removeBtn.title = 'Remove';
+            removeBtn.innerHTML = '&#x2715;';
+            removeBtn.setAttribute('onclick', 'qbRemoveNode(this)');
+            header.appendChild(removeBtn);
+        }
+        group.appendChild(header);
+
+        var itemsEl = document.createElement('div');
+        itemsEl.className = 'qb-group-items';
+        if (nodeData.items) {
+            for (var i = 0; i < nodeData.items.length; i++) {
+                if (nodeData.items[i]) qbRenderNode(nodeData.items[i], itemsEl, false);
+            }
+        }
+        group.appendChild(itemsEl);
+        parentEl.appendChild(group);
+
+    } else if (nodeData.type === 'term') {
+        var term = document.createElement('div');
+        term.className = 'qb-term';
+
+        var negLabel2 = document.createElement('label');
+        negLabel2.className = 'qb-negate-label';
+        var negChk2 = document.createElement('input');
+        negChk2.type = 'checkbox';
+        negChk2.className = 'qb-negate';
+        negChk2.setAttribute('onchange', 'qbUpdate()');
+        if (nodeData.negate) negChk2.checked = true;
+        negLabel2.appendChild(negChk2);
+        negLabel2.appendChild(document.createTextNode(' not'));
+        term.appendChild(negLabel2);
+
+        var sel = document.createElement('select');
+        sel.className = 'qb-term-type';
+        sel.setAttribute('onchange', 'qbUpdate()');
+        var optWord = document.createElement('option');
+        optWord.value = 'word';
+        optWord.textContent = 'words';
+        var optPhrase = document.createElement('option');
+        optPhrase.value = 'phrase';
+        optPhrase.textContent = 'phrase';
+        sel.appendChild(optWord);
+        sel.appendChild(optPhrase);
+        if (nodeData.termType === 'phrase') sel.value = 'phrase';
+        term.appendChild(sel);
+
+        var inp = document.createElement('input');
+        inp.type = 'text';
+        inp.className = 'qb-text';
+        inp.value = nodeData.text || '';
+        inp.setAttribute('oninput', 'qbUpdate()');
+        inp.setAttribute('onkeyup', 'seekIfSubmit(event)');
+        term.appendChild(inp);
+
+        var removeBtn2 = document.createElement('button');
+        removeBtn2.className = 'qb-remove-btn';
+        removeBtn2.type = 'button';
+        removeBtn2.title = 'Remove';
+        removeBtn2.innerHTML = '&#x2715;';
+        removeBtn2.setAttribute('onclick', 'qbRemoveNode(this)');
+        term.appendChild(removeBtn2);
+
+        parentEl.appendChild(term);
+    }
+}
+
+function qbSerializeNode(el, isRoot) {
+    if (el.classList.contains('qb-term')) {
+        var negate = el.querySelector('.qb-negate').checked;
+        var type = el.querySelector('.qb-term-type').value;
+        var text = el.querySelector('.qb-text').value.trim();
+        if (!text) return '';
+        if (type === 'phrase') {
+            return (negate ? '-' : '') + '"' + text + '"';
+        }
+        var words = text.split(/\s+/).filter(Boolean);
+        return words.map(function(w) { return (negate ? '-' : '') + w; }).join(' ');
+    }
+    if (el.classList.contains('qb-group')) {
+        var combinator = el.getAttribute('data-combinator') || 'AND';
+        var negate = el.querySelector(':scope > .qb-group-header > .qb-negate-label > .qb-negate').checked;
+        var itemsEl = el.querySelector(':scope > .qb-group-items');
+        var children = itemsEl ? itemsEl.children : [];
+        var parts = [];
+        for (var i = 0; i < children.length; i++) {
+            var s = qbSerializeNode(children[i], false);
+            if (s) parts.push(s);
+        }
+        if (parts.length === 0) return '';
+        var joined = combinator === 'OR' ? parts.join(' OR ') : parts.join(' ');
+        // Add parens if non-root, or if root but negated (to keep semantics unambiguous)
+        if (!isRoot || negate) joined = '(' + joined + ')';
+        if (negate) joined = '-' + joined;
+        return joined;
+    }
+    return '';
+}
+
+function qbUpdate() {
+    var root = document.querySelector('#qb-panel > .qb-group');
+    var qf = document.getElementById('query');
+    if (root && qf) qf.value = qbSerializeNode(root, true);
+}
+
+function qbSyncFromQuery() {
+    var panel = document.getElementById('qb-panel');
+    if (!panel || panel.style.display === 'none' || panel.style.display === '') return;
+    var q = document.getElementById('query').value;
+    qbPopulatePanel(q);
+}
+
+function qbPopulatePanel(q) {
+    var panel = document.getElementById('qb-panel');
+    var existing = panel.querySelector('.qb-group');
+    if (existing) existing.remove();
+    var tree = q.trim() ? qbParseToTree(q) : {type: 'group', combinator: 'AND', negate: false, items: []};
+    if (tree.type === 'term') tree = {type: 'group', combinator: 'AND', negate: false, items: [tree]};
+    qbRenderNode(tree, panel, true);
+}
+
+function qbToggleCombinator(btn) {
+    var group = btn.closest('.qb-group');
+    var current = group.getAttribute('data-combinator') || 'AND';
+    var next = current === 'AND' ? 'OR' : 'AND';
+    group.setAttribute('data-combinator', next);
+    btn.textContent = next;
+    qbUpdate();
+}
+
+function qbAddTermToGroup(btn) {
+    var group = btn.closest('.qb-group');
+    var itemsEl = group.querySelector(':scope > .qb-group-items');
+    qbRenderNode({type: 'term', termType: 'word', text: '', negate: false}, itemsEl, false);
+    qbUpdate();
+}
+
+function qbAddGroupToGroup(btn) {
+    var group = btn.closest('.qb-group');
+    var itemsEl = group.querySelector(':scope > .qb-group-items');
+    qbRenderNode({
+        type: 'group', combinator: 'AND', negate: false,
+        items: [{type: 'term', termType: 'word', text: '', negate: false}]
+    }, itemsEl, false);
+    qbUpdate();
+}
+
+function qbRemoveNode(btn) {
+    var node = btn.closest('.qb-term') || btn.closest('.qb-group');
+    if (node) node.remove();
+    qbUpdate();
+}
+
+function qbToggle() {
+    var panel = document.getElementById('qb-panel');
+    var toggleBtn = document.getElementById('qb-toggle');
+    if (panel.style.display === 'none' || panel.style.display === '') {
+        var qf = document.getElementById('query');
+        var q = qf ? qf.value.trim() : '';
+        qbPopulatePanel(q);
+        panel.style.display = 'block';
+        if (toggleBtn) toggleBtn.classList.add('qb-toggle-active');
+    } else {
+        panel.style.display = 'none';
+        if (toggleBtn) toggleBtn.classList.remove('qb-toggle-active');
+    }
+}
+</script>

--- a/siikr/show_page.php
+++ b/siikr/show_page.php
@@ -1,5 +1,5 @@
 <?php
-$scriptVer = 90;
+$scriptVer = 91;
 require_once 'internal/disk_stats.php';
 try {
 	$diskpath = $db_disk;   
@@ -51,8 +51,10 @@ try {
             <div id="search-fields-container">
                 <button id="show-advanced" title="Advanced Filter" onclick="showAdvanced()"><img class="gear-icon" src="images/gear.svg"></img></button>
                 <input id="username" type="text" placeholder="Username" onkeyup="seekIfSubmit(event)">
-                <input id="query" type="text" placeholder='these words OR "this phrase" -"but not this one"' onkeyup="seekIfSubmit(event)">
+                <input id="query" type="text" placeholder='these words OR "this phrase" -"but not this one"' onkeyup="seekIfSubmit(event)" oninput="qbSyncFromQuery()">
+                <button id="qb-toggle" type="button" title="Visual query builder" onclick="qbToggle()">&#9776;</button>
                 <button id="search" value="Seek" onclick="preSeek()">Seek</button>
+                <?php require_once 'query_builder.php'?>
             </div>
         </div>
         <div id="progress-container">


### PR DESCRIPTION
## Summary

- Adds a toggleable query builder panel (☰ button) next to the search bar
- Lets users construct queries visually using words, phrases, AND/OR groups, and negation — no need to remember search syntax
- Syncs bidirectionally with the raw query input field (editing the text box updates the panel and vice versa)
- Fixes `setup_simple.sh` to correctly copy `msgrouter.service` from `node_specific_data` before installing it to `/etc/systemd/system/`

## Changes

- `siikr/query_builder.php` — new file: query builder HTML + JS (tokenizer, parser, renderer, serializer)
- `siikr/css/sikr-css.css` — styles for the query builder panel and controls
- `siikr/show_page.php` — adds toggle button, includes query builder, hooks `oninput` on the query field
- `setup_simple.sh` — one-line fix for service file copy order

## Test plan

- [ ] Open the search page and click the ☰ button — query builder panel should appear
- [ ] Type a query like `hello OR "world" -foo` in the search box — panel should reflect it
- [ ] Edit terms/groups in the panel — search box should update in real time
- [ ] Submit a search from the panel (Enter key) — should work as normal
- [ ] Run `setup_simple.sh` on a fresh node and confirm the service installs correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)